### PR TITLE
Refactor desktop window hierarchy and fix issues tree key collisions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,30 +2,49 @@
 
 import React, { useState } from 'react';
 import StartMenu from "@/components/StartMenu";
-import DesktopWindow from "@/components/windows/DesktopWindow";
-
-type WindowId = "welcome" | "about" | "projects" | "contact" | "notepad" | "issues";
-type Layout = "normal" | "docked" | "maximized";
+import ProgramWindow from "@/components/windows/ProgramWindow";
+import DocumentWindow from "@/components/windows/DocumentWindow";
+import {
+  Layout,
+  WindowId,
+  isDocumentWindow,
+  isProgramWindow,
+} from "@/components/windows/windowTypes";
 
 export default function Home() {
   const [activeWindow, setActiveWindow] = useState<WindowId | null>("welcome");
   const [layout, setLayout] = useState<Layout>("normal");
 
+  const closeWindow = () => {
+    setActiveWindow(null);
+    setLayout("normal");
+  };
+
+  const restoreWindow = () => setLayout("normal");
+  const dockWindow = () => setLayout("docked");
+  const toggleMaximize = () => setLayout((l) => (l === "maximized" ? "normal" : "maximized"));
+
   return (
     <main style={{ width: "100vw", height: "100vh", position: "relative" }}>
-      {activeWindow && (
-        <DesktopWindow
+      {activeWindow && isProgramWindow(activeWindow) && (
+        <ProgramWindow
           id={activeWindow}
           layout={layout}
-          onClose={() => {
-            setActiveWindow(null);
-            setLayout("normal");
-          }}
-          onMinimize={() => setLayout("docked")}
-          onRestore={() => setLayout("normal")}
-          onToggleMaximize={() =>
-            setLayout(l => (l === "maximized" ? "normal" : "maximized"))
-          }
+          onClose={closeWindow}
+          onMinimize={dockWindow}
+          onRestore={restoreWindow}
+          onToggleMaximize={toggleMaximize}
+        />
+      )}
+
+      {activeWindow && isDocumentWindow(activeWindow) && (
+        <DocumentWindow
+          id={activeWindow}
+          layout={layout}
+          onClose={closeWindow}
+          onMinimize={dockWindow}
+          onRestore={restoreWindow}
+          onToggleMaximize={toggleMaximize}
         />
       )}
 

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -5,8 +5,7 @@ import { AppBar, Button, MenuList, MenuListItem, Separator, Toolbar, TextInput }
 import { Z } from "@/constants/zIndex";
 import { Sizes } from "react95/dist/types";
 import { usePower } from "@/components/power/PowerProvider";
-
-type WindowId = "welcome" | "about" | "projects" | "contact" | "notepad" | "issues";
+import { WindowId } from "@/components/windows/windowTypes";
 
 type MenuAction = () => void;
 

--- a/src/components/issues/IssuesTreeView.tsx
+++ b/src/components/issues/IssuesTreeView.tsx
@@ -6,7 +6,8 @@ import React, {
     useMemo,
     useState,
 } from "react";
-import { GroupBox, TreeLeaf, TreeView } from "react95";
+import { GroupBox, TreeLeaf } from "react95";
+import { TreeView } from "@/components/issues/React95TreeViewPatched";
 
 import issuesRaw from "@/data/issues.json";
 
@@ -375,19 +376,21 @@ const IssuesTreeView = forwardRef<IssuesTreeViewHandle, Props>(
             }
         `;
 
+        const PatchedTreeView = TreeView as any;
+
         const content = (
             <div style={{ overflow: "auto", padding: 2 }}>
                 <TreeContainer>
-                    <TreeView
+                    <PatchedTreeView
                         tree={tree}
                         selected={selected as any}
                         expanded={expanded}
-                        onNodeSelect={(_, idOrIds) => {
+                        onNodeSelect={(_event: unknown, idOrIds: unknown) => {
                             const next = normalizeSelected(idOrIds, selected[0] ?? initialSelected);
                             setSelected(next);
                             onSelectId?.(next[0]);
                         }}
-                        onNodeToggle={(_, ids) => setExpanded(uniq(ids))}
+                        onNodeToggle={(_event: unknown, ids: string[]) => setExpanded(uniq(ids))}
                     />
                 </TreeContainer>
             </div>

--- a/src/components/issues/React95TreeViewPatched.js
+++ b/src/components/issues/React95TreeViewPatched.js
@@ -1,0 +1,333 @@
+"use client";
+
+import React from "react";
+import styled, { css } from "styled-components";
+import useControlledOrUncontrolled from "react95/dist/common/hooks/useControlledOrUncontrolled.js";
+import * as SwitchBase from "react95/dist/common/SwitchBase.js";
+
+const Text = styled(SwitchBase.LabelText)`
+  white-space: nowrap;
+`;
+
+const focusedElementStyles = css`
+  :focus {
+    outline: none;
+  }
+
+  ${({ $disabled }) =>
+    !$disabled
+      ? css`
+          cursor: pointer;
+
+          :focus {
+            ${Text} {
+              background: ${({ theme }) => theme.hoverBackground};
+              color: ${({ theme }) => theme.materialTextInvert};
+              outline: 2px dotted ${({ theme }) => theme.focusSecondary};
+            }
+          }
+        `
+      : "cursor: default;"}
+`;
+
+const TreeWrapper = styled.ul`
+  position: relative;
+  isolation: isolate;
+
+  ${({ isRootLevel }) =>
+    isRootLevel &&
+    css`
+      &:before {
+        content: "";
+        position: absolute;
+        top: 20px;
+        bottom: 0;
+        left: 5.5px;
+        width: 1px;
+        border-left: 2px dashed ${({ theme }) => theme.borderDark};
+      }
+    `}
+
+  ul {
+    padding-left: 19.5px;
+  }
+
+  li {
+    position: relative;
+
+    &:before {
+      content: "";
+      position: absolute;
+      top: 17.5px;
+      left: 5.5px;
+      width: 22px;
+      border-top: 2px dashed ${({ theme }) => theme.borderDark};
+      font-size: 12px;
+    }
+  }
+`;
+
+const TreeItem = styled.li`
+  position: relative;
+  padding-left: ${({ hasItems }) => (!hasItems ? "13px" : "0")};
+
+  ${({ isRootLevel }) =>
+    !isRootLevel
+      ? css`
+          &:last-child {
+            &:after {
+              content: "";
+              position: absolute;
+              z-index: 1;
+              top: 19.5px;
+              bottom: 0;
+              left: 1.5px;
+              width: 10px;
+              background: ${({ theme }) => theme.material};
+            }
+          }
+        `
+      : css`
+          &:last-child {
+            &:after {
+              content: "";
+              position: absolute;
+              top: 19.5px;
+              left: 1px;
+              bottom: 0;
+              width: 10px;
+              background: ${({ theme }) => theme.material};
+            }
+          }
+        `}
+
+  & > details > ul {
+    &:after {
+      content: "";
+      position: absolute;
+      top: -18px;
+      bottom: 0;
+      left: 25px;
+      border-left: 2px dashed ${({ theme }) => theme.borderDark};
+    }
+  }
+`;
+
+const Details = styled.details`
+  position: relative;
+  z-index: 2;
+
+  &[open] > summary:before {
+    content: "-";
+  }
+`;
+
+const Summary = styled.summary`
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  color: ${({ theme }) => theme.materialText};
+  user-select: none;
+  padding-left: 18px;
+  ${focusedElementStyles};
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &:before {
+    content: "+";
+    position: absolute;
+    left: 0;
+    display: block;
+    width: 8px;
+    height: 9px;
+    border: 2px solid #808080;
+    padding-left: 1px;
+    background-color: #fff;
+    line-height: 8px;
+    text-align: center;
+  }
+`;
+
+const TitleWithIcon = styled(SwitchBase.StyledLabel)`
+  position: relative;
+  z-index: 1;
+  background: none;
+  border: 0;
+  font-family: inherit;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin: 0;
+  ${focusedElementStyles};
+`;
+
+const Icon = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-right: 6px;
+`;
+
+function toggleItem(state, id) {
+  return state.includes(id) ? state.filter((item) => item !== id) : [...state, id];
+}
+
+function preventDefault(event) {
+  event.preventDefault();
+}
+
+function TreeBranch({ className, disabled, expanded, innerRef, level, select, selected, style, tree = [] }) {
+  const isRootLevel = level === 0;
+
+  const renderLeaf = React.useCallback(
+    (item) => {
+      const hasItems = Boolean(item.items && item.items.length > 0);
+      const isMenuShown = expanded.includes(item.id);
+      const isNodeDisabled = disabled || item.disabled || false;
+      const onClickSummary = !isNodeDisabled ? (event) => select(event, item) : preventDefault;
+      const onClickLeaf = !isNodeDisabled ? (event) => select(event, item) : preventDefault;
+      const isSelected = selected === item.id;
+      const icon = <Icon aria-hidden>{item.icon}</Icon>;
+
+      return (
+        // Only change vs upstream: key by id (stable/unique), not label.
+        <TreeItem
+          key={item.id}
+          isRootLevel={isRootLevel}
+          role="treeitem"
+          aria-expanded={isMenuShown}
+          aria-selected={isSelected}
+          hasItems={hasItems}
+        >
+          {!hasItems ? (
+            <TitleWithIcon as="button" $disabled={isNodeDisabled} onClick={onClickLeaf}>
+              {icon}
+              <Text>{item.label}</Text>
+            </TitleWithIcon>
+          ) : (
+            <Details open={isMenuShown}>
+              <Summary onClick={onClickSummary} $disabled={isNodeDisabled}>
+                <TitleWithIcon $disabled={isNodeDisabled}>
+                  {icon}
+                  <Text>{item.label}</Text>
+                </TitleWithIcon>
+              </Summary>
+              {isMenuShown && (
+                <TreeBranch
+                  className={className}
+                  disabled={isNodeDisabled}
+                  expanded={expanded}
+                  level={level + 1}
+                  select={select}
+                  selected={selected}
+                  style={style}
+                  tree={item.items || []}
+                />
+              )}
+            </Details>
+          )}
+        </TreeItem>
+      );
+    },
+    [className, disabled, expanded, isRootLevel, level, select, selected, style]
+  );
+
+  return (
+    <TreeWrapper
+      className={isRootLevel ? className : undefined}
+      style={isRootLevel ? style : undefined}
+      ref={isRootLevel ? innerRef : undefined}
+      role={isRootLevel ? "tree" : "group"}
+      isRootLevel={isRootLevel}
+    >
+      {tree.map(renderLeaf)}
+    </TreeWrapper>
+  );
+}
+
+function TreeInner(
+  {
+    className,
+    defaultExpanded = [],
+    defaultSelected,
+    disabled = false,
+    expanded,
+    onNodeSelect,
+    onNodeToggle,
+    selected,
+    style,
+    tree = [],
+  },
+  ref
+) {
+  const [expandedInternal, setExpandedInternal] = useControlledOrUncontrolled({
+    defaultValue: defaultExpanded,
+    onChange: onNodeToggle,
+    onChangePropName: "onNodeToggle",
+    value: expanded,
+    valuePropName: "expanded",
+  });
+
+  const [selectedInternal, setSelectedInternal] = useControlledOrUncontrolled({
+    defaultValue: defaultSelected,
+    onChange: onNodeSelect,
+    onChangePropName: "onNodeSelect",
+    value: selected,
+    valuePropName: "selected",
+  });
+
+  const toggleMenu = React.useCallback(
+    (event, id) => {
+      if (onNodeToggle) {
+        const newState = toggleItem(expandedInternal, id);
+        onNodeToggle(event, newState);
+      }
+      setExpandedInternal((previouslyExpandedIds) => toggleItem(previouslyExpandedIds, id));
+    },
+    [expandedInternal, onNodeToggle, setExpandedInternal]
+  );
+
+  const select = React.useCallback(
+    (event, id) => {
+      setSelectedInternal(id);
+      if (onNodeSelect) {
+        onNodeSelect(event, id);
+      }
+    },
+    [onNodeSelect, setSelectedInternal]
+  );
+
+  const handleSelect = React.useCallback(
+    (event, item) => {
+      event.preventDefault();
+      select(event, item.id);
+      if (item.items && item.items.length) {
+        toggleMenu(event, item.id);
+      }
+    },
+    [select, toggleMenu]
+  );
+
+  return (
+    <TreeBranch
+      className={className}
+      disabled={disabled}
+      expanded={expandedInternal}
+      level={0}
+      innerRef={ref}
+      select={handleSelect}
+      selected={selectedInternal}
+      style={style}
+      tree={tree}
+    />
+  );
+}
+
+const TreeView = React.forwardRef(TreeInner);
+TreeView.displayName = "TreeView";
+
+export { TreeView };

--- a/src/components/windows/DesktopWindow.tsx
+++ b/src/components/windows/DesktopWindow.tsx
@@ -1,100 +1,76 @@
 "use client";
 
-import React, { useRef } from "react";
-import {
-  Anchor,
-  Button,
-  ScrollView,
-  TextInput,
-  Window,
-  WindowHeader,
-  WindowContent,
-  Toolbar,
-} from "react95";
+import React from "react";
+import { Button, Toolbar, Window, WindowContent, WindowHeader } from "react95";
 import { Z } from "@/constants/zIndex";
-import IssuesTreeView, { IssuesTreeViewHandle } from "@/components/issues/IssuesTreeView";
+import { Layout } from "@/components/windows/windowTypes";
 
-type WindowId = "welcome" | "about" | "projects" | "contact" | "notepad" | "issues";
-type Layout = "normal" | "docked" | "maximized";
-
-export default function DesktopWindow({
-  id,
-  layout,
-  onClose,
-  onMinimize,
-  onRestore,
-  onToggleMaximize,
-}: {
-  id: WindowId;
+type DesktopWindowProps = {
+  title: string;
   layout: Layout;
+  normalHeight: number;
   onClose: () => void;
   onMinimize: () => void;
   onRestore: () => void;
   onToggleMaximize: () => void;
-}) {
-  const title =
-    id === "contact"
-      ? "contact.txt"
-      : id === "about"
-        ? "about.txt"
-        : id === "projects"
-          ? "projects.txt"
-          : id == "notepad"
-            ? "notepad.exe"
-            : id == "issues"
-              ? "issues.exe"
-              : "mrwr.dev";
+  toolbar?: React.ReactNode;
+  children: React.ReactNode;
+};
 
+export default function DesktopWindow({
+  title,
+  layout,
+  normalHeight,
+  onClose,
+  onMinimize,
+  onRestore,
+  onToggleMaximize,
+  toolbar,
+  children,
+}: DesktopWindowProps) {
   const isMax = layout === "maximized";
   const isDocked = layout === "docked";
-  const isDocument = id === "contact" || id === "about" || id == "projects";
-  const hasToolbar = id === "issues"
 
-  // Tune these to match your real taskbar size + desired margins
   const TASKBAR_H = 50;
   const GAP = 8;
 
   const NORMAL_W = 280;
-  const NORMAL_H = isDocument ? 200 : id === "welcome" ? 160 : 300;
-
   const DOCK_W = 200;
   const DOCK_H = 60;
 
-  const treeRef = useRef<IssuesTreeViewHandle>(null);
-
   const style: React.CSSProperties = isMax
     ? {
-      position: "absolute",
-      top: TASKBAR_H + GAP,
-      left: GAP,
-      width: `calc(100vw - ${GAP * 2}px)`,
-      height: `calc(100vh - ${TASKBAR_H + GAP * 2}px)`,
-      zIndex: Z.WINDOW,
-      display: "flex",
-      flexDirection: "column",
-    }
-    : isDocked
-      ? {
         position: "absolute",
+        top: TASKBAR_H + GAP,
         left: GAP,
-        bottom: GAP,
-        width: DOCK_W,
-        height: DOCK_H,
+        width: `calc(100vw - ${GAP * 2}px)`,
+        height: `calc(100vh - ${TASKBAR_H + GAP * 2}px)`,
         zIndex: Z.WINDOW,
         display: "flex",
         flexDirection: "column",
       }
+    : isDocked
+      ? {
+          position: "absolute",
+          left: GAP,
+          bottom: GAP,
+          width: DOCK_W,
+          height: DOCK_H,
+          zIndex: Z.WINDOW,
+          display: "flex",
+          flexDirection: "column",
+        }
       : {
-        position: "absolute",
-        left: "50%",
-        top: `calc(50% + ${TASKBAR_H / 2}px)`,
-        transform: "translate(-50%, -50%)",
-        width: NORMAL_W,
-        height: NORMAL_H,
-        zIndex: Z.WINDOW,
-        display: "flex",
-        flexDirection: "column",
-      };
+          position: "absolute",
+          left: "50%",
+          top: `calc(50% + ${TASKBAR_H / 2}px)`,
+          transform: "translate(-50%, -50%)",
+          width: NORMAL_W,
+          height: normalHeight,
+          zIndex: Z.WINDOW,
+          display: "flex",
+          flexDirection: "column",
+        };
 
   return (
     <Window style={style}>
@@ -128,194 +104,31 @@ export default function DesktopWindow({
           </Button>
         </div>
       </WindowHeader>
-      {hasToolbar && <Toolbar style={{
-        padding: "1px 1px",
-        marginBottom: 0,
-        gap: 2,
-      }}
-      >
-        <Button variant="menu" size="sm" onClick={() => treeRef.current?.expandOpen()}>⚠️</Button>
-        <Button variant="menu" size="sm" onClick={() => treeRef.current?.expandClosed()}>✅</Button>
-        <Button variant="menu" size="sm" onClick={() => treeRef.current?.expandAll()}>➕</Button>
-        <Button variant="menu" size="sm" onClick={() => treeRef.current?.collapseAll()}>➖</Button>
-      </Toolbar>}
+
+      {toolbar && (
+        <Toolbar
+          style={{
+            padding: "1px 1px",
+            marginBottom: 0,
+            gap: 2,
+          }}
+        >
+          {toolbar}
+        </Toolbar>
+      )}
+
       {!isDocked && (
         <WindowContent
-          // Key: let content be the remaining height, and allow it to shrink
           style={{
             flex: "1 1 auto",
             minHeight: 0,
             display: "flex",
             flexDirection: "column",
             padding: 6,
-            gap: 2
+            gap: 2,
           }}
         >
-          {id === "welcome" && (
-            <div>
-              coming soon…
-              <br />
-              you can help:
-              <ul>
-                <li>
-                  - found a bug? let me know!
-                </li>
-                <li>
-                  - type brief description in search bar
-                </li>
-                <li>
-                  - buy me a{" "}
-                  <Anchor href="https://buymeacoffee.com/rattmouse" target="_blank">
-                    ☕
-                  </Anchor>
-                </li>
-              </ul>
-            </div>
-          )}
-
-          {id === "notepad" && (
-            <div style={{ flex: "1 1 auto", minHeight: 0, width: "100%", minWidth: 0 }}>
-              <TextInput
-                multiline
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  boxSizing: "border-box",
-                  minWidth: 0,
-                  minHeight: 0,
-                }}
-              />
-            </div>
-          )}
-
-          {id === "issues" && (
-            <div style={{ flex: "1 1 auto", minHeight: 0, minWidth: 0 }}>
-
-              <ScrollView style={{ width: "100%", height: "100%" }}>
-                <IssuesTreeView ref={treeRef} showFrame={false} />
-              </ScrollView>
-            </div>
-          )}
-
-          {id === "projects" &&
-            <>
-              <h1>can't share most of them</h1>
-              <ul>
-                <li>
-                  - but this one is on{" "}
-                  <Anchor href="https://github.com/rattmouse/mrwr.dev" target="_blank">
-                    GitHub
-                  </Anchor>
-                </li>
-              </ul>
-            </>}
-
-          {(id === "about" || id === "contact") && (
-            // This wrapper is what actually controls the scroll area size
-            <div style={{ flex: "1 1 auto", minHeight: 0 }}>
-              <ScrollView style={{ width: "100%", height: "100%" }}>
-                {id === "about" && (
-                  <>
-                    <h1>web app created by Matt Rouse</h1>
-                    <ul>
-                      <li>
-                        - ui created with{" "}
-                        <Anchor href="https://react95.io/" target="_blank">
-                          react95
-                        </Anchor>
-                      </li>
-                      <li>
-                        - built with{" "}
-                        <Anchor href="https://nextjs.org/" target="_blank">
-                          Next.js
-                        </Anchor>{" "}
-                        &{" "}
-                        <Anchor href="https://react.dev/" target="_blank">
-                          React
-                        </Anchor>
-                      </li>
-                      <li>
-                        - deployed on{" "}
-                        <Anchor href="https://www.digitalocean.com/" target="_blank">
-                          DigitalOcean
-                        </Anchor>
-                      </li>
-                      <li>
-                        - some help from{" "}
-                        <Anchor href="https://chatgpt.com/" target="_blank">
-                          Chat GPT
-                        </Anchor>
-                      </li>
-                      <li>
-                        - and a lot of help from{" "}
-                        <Anchor href="https://chatgpt.com/codex/" target="_blank">
-                          Codex
-                        </Anchor>
-                      </li>
-                    </ul>
-                  </>
-                )}
-
-                {id === "contact" && (
-                  <>
-                    <h1>contact links:</h1>
-                    <ul>
-                      <li>
-                        -{" "}
-                        <Anchor href="https://t.me/rattmouse" target="_blank">
-                          Telegram
-                        </Anchor>
-                      </li>
-                      <li>
-                        -{" "}
-                        <Anchor href="https://signal.me/#eu/rattmouse.113" target="_blank">
-                          Signal
-                        </Anchor>
-                      </li>
-                      <li>
-                        -{" "}
-                        <Anchor href="mailto:rattmouse@pm.me" target="_blank">
-                          rattmouse@pm.me
-                        </Anchor>
-                      </li>
-                    </ul>
-                    <br />
-                    <h1>social links:</h1>
-                    <ul>
-                      <li>
-                        -{" "}
-                        <Anchor href="https://instagram.com/ratt.mouse" target="_blank">
-                          Instagram
-                        </Anchor>
-                      </li>
-                      <li>
-                        -{" "}
-                        <Anchor href="https://www.linkedin.com/in/rattmouse/" target="_blank">
-                          LinkedIn
-                        </Anchor>
-                      </li>
-                      <li>
-                        -{" "}
-                        <Anchor href="https://discord.com/channels/@rattmouse" target="_blank">
-                          Discord
-                        </Anchor>
-                      </li>
-                    </ul>
-                    <br />
-                    <h1>other links:</h1>
-                    <ul>
-                      <li>
-                        -{" "}
-                        <Anchor href="https://linktr.ee/ratt.mouse" target="_blank">
-                          linktr.ee
-                        </Anchor>
-                      </li>
-                    </ul>
-                  </>
-                )}
-              </ScrollView>
-            </div>
-          )}
+          {children}
         </WindowContent>
       )}
     </Window>

--- a/src/components/windows/DocumentWindow.tsx
+++ b/src/components/windows/DocumentWindow.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import React from "react";
+import { Anchor, ScrollView } from "react95";
+import DesktopWindow from "@/components/windows/DesktopWindow";
+import { DocumentWindowId, Layout } from "@/components/windows/windowTypes";
+
+type DocumentWindowProps = {
+  id: DocumentWindowId;
+  layout: Layout;
+  onClose: () => void;
+  onMinimize: () => void;
+  onRestore: () => void;
+  onToggleMaximize: () => void;
+};
+
+export default function DocumentWindow({
+  id,
+  layout,
+  onClose,
+  onMinimize,
+  onRestore,
+  onToggleMaximize,
+}: DocumentWindowProps) {
+  const title = id === "about" ? "about.txt" : id === "contact" ? "contact.txt" : "projects.txt";
+
+  return (
+    <DesktopWindow
+      title={title}
+      layout={layout}
+      normalHeight={200}
+      onClose={onClose}
+      onMinimize={onMinimize}
+      onRestore={onRestore}
+      onToggleMaximize={onToggleMaximize}
+    >
+      {id === "projects" && (
+        <>
+          <h1>can't share most of them</h1>
+          <ul>
+            <li>
+              - but this one is on{" "}
+              <Anchor href="https://github.com/rattmouse/mrwr.dev" target="_blank">
+                GitHub
+              </Anchor>
+            </li>
+          </ul>
+        </>
+      )}
+
+      {(id === "about" || id === "contact") && (
+        <div style={{ flex: "1 1 auto", minHeight: 0 }}>
+          <ScrollView style={{ width: "100%", height: "100%" }}>
+            {id === "about" && (
+              <>
+                <h1>web app created by Matt Rouse</h1>
+                <ul>
+                  <li>
+                    - ui created with{" "}
+                    <Anchor href="https://react95.io/" target="_blank">
+                      react95
+                    </Anchor>
+                  </li>
+                  <li>
+                    - built with{" "}
+                    <Anchor href="https://nextjs.org/" target="_blank">
+                      Next.js
+                    </Anchor>{" "}
+                    &{" "}
+                    <Anchor href="https://react.dev/" target="_blank">
+                      React
+                    </Anchor>
+                  </li>
+                  <li>
+                    - deployed on{" "}
+                    <Anchor href="https://www.digitalocean.com/" target="_blank">
+                      DigitalOcean
+                    </Anchor>
+                  </li>
+                  <li>
+                    - some help from{" "}
+                    <Anchor href="https://chatgpt.com/" target="_blank">
+                      Chat GPT
+                    </Anchor>
+                  </li>
+                  <li>
+                    - and a lot of help from{" "}
+                    <Anchor href="https://chatgpt.com/codex/" target="_blank">
+                      Codex
+                    </Anchor>
+                  </li>
+                </ul>
+              </>
+            )}
+
+            {id === "contact" && (
+              <>
+                <h1>contact links:</h1>
+                <ul>
+                  <li>
+                    -{" "}
+                    <Anchor href="https://t.me/rattmouse" target="_blank">
+                      Telegram
+                    </Anchor>
+                  </li>
+                  <li>
+                    -{" "}
+                    <Anchor href="https://signal.me/#eu/rattmouse.113" target="_blank">
+                      Signal
+                    </Anchor>
+                  </li>
+                  <li>
+                    -{" "}
+                    <Anchor href="mailto:rattmouse@pm.me" target="_blank">
+                      rattmouse@pm.me
+                    </Anchor>
+                  </li>
+                </ul>
+                <br />
+                <h1>social links:</h1>
+                <ul>
+                  <li>
+                    -{" "}
+                    <Anchor href="https://instagram.com/ratt.mouse" target="_blank">
+                      Instagram
+                    </Anchor>
+                  </li>
+                  <li>
+                    -{" "}
+                    <Anchor href="https://www.linkedin.com/in/rattmouse/" target="_blank">
+                      LinkedIn
+                    </Anchor>
+                  </li>
+                  <li>
+                    -{" "}
+                    <Anchor href="https://discord.com/channels/@rattmouse" target="_blank">
+                      Discord
+                    </Anchor>
+                  </li>
+                </ul>
+                <br />
+                <h1>other links:</h1>
+                <ul>
+                  <li>
+                    -{" "}
+                    <Anchor href="https://linktr.ee/ratt.mouse" target="_blank">
+                      linktr.ee
+                    </Anchor>
+                  </li>
+                </ul>
+              </>
+            )}
+          </ScrollView>
+        </div>
+      )}
+    </DesktopWindow>
+  );
+}

--- a/src/components/windows/ProgramWindow.tsx
+++ b/src/components/windows/ProgramWindow.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import React, { useRef } from "react";
+import { Anchor, Button, ScrollView, TextInput } from "react95";
+import IssuesTreeView, { IssuesTreeViewHandle } from "@/components/issues/IssuesTreeView";
+import DesktopWindow from "@/components/windows/DesktopWindow";
+import { Layout, ProgramWindowId } from "@/components/windows/windowTypes";
+
+type ProgramWindowProps = {
+  id: ProgramWindowId;
+  layout: Layout;
+  onClose: () => void;
+  onMinimize: () => void;
+  onRestore: () => void;
+  onToggleMaximize: () => void;
+};
+
+export default function ProgramWindow({
+  id,
+  layout,
+  onClose,
+  onMinimize,
+  onRestore,
+  onToggleMaximize,
+}: ProgramWindowProps) {
+  const treeRef = useRef<IssuesTreeViewHandle>(null);
+
+  const title =
+    id === "notepad"
+      ? "notepad.exe"
+      : id === "issues"
+        ? "issues.exe"
+        : "mrwr.dev";
+
+  const normalHeight = id === "welcome" ? 160 : 300;
+
+  const toolbar =
+    id === "issues" ? (
+      <>
+        <Button variant="menu" size="sm" onClick={() => treeRef.current?.expandOpen()}>
+          ⚠️
+        </Button>
+        <Button variant="menu" size="sm" onClick={() => treeRef.current?.expandClosed()}>
+          ✅
+        </Button>
+        <Button variant="menu" size="sm" onClick={() => treeRef.current?.expandAll()}>
+          ➕
+        </Button>
+        <Button variant="menu" size="sm" onClick={() => treeRef.current?.collapseAll()}>
+          ➖
+        </Button>
+      </>
+    ) : undefined;
+
+  return (
+    <DesktopWindow
+      title={title}
+      layout={layout}
+      normalHeight={normalHeight}
+      onClose={onClose}
+      onMinimize={onMinimize}
+      onRestore={onRestore}
+      onToggleMaximize={onToggleMaximize}
+      toolbar={toolbar}
+    >
+      {id === "welcome" && (
+        <div>
+          coming soon…
+          <br />
+          you can help:
+          <ul>
+            <li>- found a bug? let me know!</li>
+            <li>- type brief description in search bar</li>
+            <li>
+              - buy me a{" "}
+              <Anchor href="https://buymeacoffee.com/rattmouse" target="_blank">
+                ☕
+              </Anchor>
+            </li>
+          </ul>
+        </div>
+      )}
+
+      {id === "notepad" && (
+        <div style={{ flex: "1 1 auto", minHeight: 0, width: "100%", minWidth: 0 }}>
+          <TextInput
+            multiline
+            style={{
+              width: "100%",
+              height: "100%",
+              boxSizing: "border-box",
+              minWidth: 0,
+              minHeight: 0,
+            }}
+          />
+        </div>
+      )}
+
+      {id === "issues" && (
+        <div style={{ flex: "1 1 auto", minHeight: 0, minWidth: 0 }}>
+          <ScrollView style={{ width: "100%", height: "100%" }}>
+            <IssuesTreeView ref={treeRef} showFrame={false} />
+          </ScrollView>
+        </div>
+      )}
+    </DesktopWindow>
+  );
+}

--- a/src/components/windows/windowTypes.ts
+++ b/src/components/windows/windowTypes.ts
@@ -1,0 +1,14 @@
+export type WindowId = "welcome" | "about" | "projects" | "contact" | "notepad" | "issues";
+
+export type ProgramWindowId = "welcome" | "notepad" | "issues";
+export type DocumentWindowId = "about" | "projects" | "contact";
+
+export type Layout = "normal" | "docked" | "maximized";
+
+export function isProgramWindow(id: WindowId): id is ProgramWindowId {
+  return id === "welcome" || id === "notepad" || id === "issues";
+}
+
+export function isDocumentWindow(id: WindowId): id is DocumentWindowId {
+  return id === "about" || id === "projects" || id === "contact";
+}


### PR DESCRIPTION
## Summary
- refactor the window architecture so DesktopWindow is the shared parent container
- introduce ProgramWindow (welcome/notepad/issues) and DocumentWindow (about/projects/contact) specializations
- centralize shared window types and guards in windowTypes.ts
- keep React95 tree styling in Issues by using a patched TreeView keyed by id instead of label
- preserve PS1 colored entries and multiline issue/comment rendering

## Validation
- npm run build

Fixes #22