### PR TITLE
Refine music window osc strip and desktop behavior

### DIFF
--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -169,7 +169,7 @@ export default function StartMenu({
   };
 
   const handleShutdown = () => {
-    shutdown({ refreshOnBootClick: true });
+    shutdown();
   };
 
   const menuItems = [
@@ -194,7 +194,7 @@ export default function StartMenu({
           { label: "Notepad", icon: "../w95_notepad.ico", size: "sm", onClick: () => pick("notepad") },
           { label: "Issues", icon: "../w98_issues.ico", size: "sm", onClick: () => pick("issues") },
           { label: "Changes", icon: "../w95_changes.ico", size: "sm", onClick: () => pick("changes") },
-          { label: "Music", icon: "../w95_music.ico", size: "sm", onClick: () => pick("osci") }
+          { label: "Music", icon: "../w95_music.ico", size: "sm", onClick: () => pick("music") }
         ],
     },
     { separator: true },

--- a/src/components/power/PowerProvider.tsx
+++ b/src/components/power/PowerProvider.tsx
@@ -4,13 +4,9 @@ import React, { createContext, useContext, useEffect, useMemo, useRef, useState 
 
 type PowerState = "on" | "shuttingDown" | "off" | "booting";
 
-type ShutdownOptions = {
-  refreshOnBootClick?: boolean;
-};
-
 type PowerContextValue = {
   state: PowerState;
-  shutdown: (options?: ShutdownOptions) => void;
+  shutdown: () => void;
   powerOn: () => void; // “reboot” (from off)
 };
 
@@ -21,7 +17,7 @@ const STORAGE_KEY = "mrwr:poweredOff";
 export function PowerProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<PowerState>("on");
   const timerRef = useRef<number | null>(null);
-  const refreshOnNextBootClickRef = useRef(false);
+  const refreshOnBootRef = useRef(false);
 
   const clearTimer = () => {
     if (timerRef.current != null) {
@@ -52,10 +48,9 @@ export function PowerProvider({ children }: { children: React.ReactNode }) {
     }
   }, [state]);
 
-  const shutdown = (options?: ShutdownOptions) => {
+  const shutdown = () => {
     // Only allow shutdown from ON
     if (state !== "on") return;
-    refreshOnNextBootClickRef.current = !!options?.refreshOnBootClick;
 
     setState("shuttingDown");
     clearTimer();
@@ -69,20 +64,10 @@ export function PowerProvider({ children }: { children: React.ReactNode }) {
   const powerOn = () => {
     // Only allow “reboot” from OFF
     if (state !== "off") return;
-    const shouldRefreshAfterBoot = refreshOnNextBootClickRef.current;
-    refreshOnNextBootClickRef.current = false;
+    refreshOnBootRef.current = true;
 
     setState("booting");
     clearTimer();
-    // duration should match your boot animation length
-    timerRef.current = window.setTimeout(() => {
-      if (shouldRefreshAfterBoot) {
-        window.location.reload();
-        return;
-      }
-      setState("on");
-      timerRef.current = null;
-    }, 1800);
   };
 
   // When booting is triggered by refresh (mount), auto-finish to ON
@@ -91,6 +76,11 @@ export function PowerProvider({ children }: { children: React.ReactNode }) {
 
     clearTimer();
     timerRef.current = window.setTimeout(() => {
+      if (refreshOnBootRef.current) {
+        refreshOnBootRef.current = false;
+        window.location.reload();
+        return;
+      }
       setState("on");
       timerRef.current = null;
     }, 1800);

--- a/src/components/windows/DesktopWindow.tsx
+++ b/src/components/windows/DesktopWindow.tsx
@@ -10,6 +10,8 @@ type DesktopWindowProps = {
   layout: Layout;
   normalWidth?: number;
   normalHeight: number;
+  normalPosition?: "center" | "topRightQuadrantCenter";
+  effectOutline?: number;
   onClose: () => void;
   onMinimize: () => void;
   onRestore: () => void;
@@ -23,6 +25,8 @@ export default function DesktopWindow({
   layout,
   normalWidth = 280,
   normalHeight,
+  normalPosition = "center",
+  effectOutline = 0,
   onClose,
   onMinimize,
   onRestore,
@@ -42,6 +46,13 @@ export default function DesktopWindow({
   const TITLE_CHAR_PX = 10;
   const DOCK_BASE_CHROME_PX = 124; // tighter header padding + 3 control buttons
   const dockWidth = Math.max(DOCK_W, DOCK_BASE_CHROME_PX + title.length * TITLE_CHAR_PX);
+  const normalLeft = normalPosition === "topRightQuadrantCenter" ? "75vw" : "50%";
+  const normalTop = normalPosition === "topRightQuadrantCenter" ? `calc(25vh + ${TASKBAR_H / 2}px)` : `calc(50% + ${TASKBAR_H / 2}px)`;
+  const outline = Math.max(0, Math.min(1, effectOutline));
+  const frameShadow =
+    outline > 0
+      ? `0 0 ${5 + 12 * outline}px rgba(0, 255, 186, ${0.2 + 0.28 * outline}), 0 0 0 1px rgba(0, 255, 186, ${0.25 + 0.5 * outline})`
+      : undefined;
 
   const style: React.CSSProperties = isMax
     ? {
@@ -53,6 +64,7 @@ export default function DesktopWindow({
         zIndex: Z.WINDOW,
         display: "flex",
         flexDirection: "column",
+        boxShadow: frameShadow,
       }
     : isDocked
       ? {
@@ -64,17 +76,19 @@ export default function DesktopWindow({
           zIndex: Z.WINDOW,
           display: "flex",
           flexDirection: "column",
+          boxShadow: frameShadow,
         }
       : {
           position: "absolute",
-          left: "50%",
-          top: `calc(50% + ${TASKBAR_H / 2}px)`,
+          left: normalLeft,
+          top: normalTop,
           transform: "translate(-50%, -50%)",
           width: NORMAL_W,
           height: normalHeight,
           zIndex: Z.WINDOW,
           display: "flex",
           flexDirection: "column",
+          boxShadow: frameShadow,
         };
 
   return (

--- a/src/components/windows/OscilloscopeWindow.tsx
+++ b/src/components/windows/OscilloscopeWindow.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+
+const ANALYZER_ID = 1;
+
+function normalizeSample(v: number): number {
+  if (!Number.isFinite(v)) return 0;
+  if (v >= -1 && v <= 1) return v;
+  return (v / 128) - 1;
+}
+
+export default function OscilloscopeWindow() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const latestSamplesRef = useRef<Float32Array | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const resize = () => {
+      const rect = canvas.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.max(1, Math.floor(rect.width * dpr));
+      canvas.height = Math.max(1, Math.floor(rect.height * dpr));
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    resize();
+    window.addEventListener("resize", resize);
+
+    const onScopeData = (event: Event) => {
+      const custom = event as CustomEvent<{ id?: number; samples?: ArrayLike<number> }>;
+      if (custom.detail?.id !== ANALYZER_ID) return;
+      const samples = custom.detail?.samples;
+      if (!samples) return;
+      latestSamplesRef.current = Float32Array.from(samples);
+    };
+    window.addEventListener("strudel-scope-data", onScopeData as EventListener);
+
+    let raf = 0;
+    const draw = () => {
+      const w = canvas.clientWidth;
+      const h = canvas.clientHeight;
+
+      ctx.fillStyle = "#0d1010";
+      ctx.fillRect(0, 0, w, h);
+
+      ctx.strokeStyle = "rgba(85, 110, 106, 0.26)";
+      ctx.lineWidth = 1;
+      for (let i = 1; i < 10; i += 1) {
+        const x = (w * i) / 10;
+        ctx.beginPath();
+        ctx.moveTo(x, 0);
+        ctx.lineTo(x, h);
+        ctx.stroke();
+      }
+      for (let i = 1; i < 6; i += 1) {
+        const y = (h * i) / 6;
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(w, y);
+        ctx.stroke();
+      }
+
+      const timeData = latestSamplesRef.current;
+      const hasSignal = !!timeData && timeData.length > 0;
+      const mid = h / 2;
+
+      ctx.strokeStyle = "rgba(0, 255, 186, 0.28)";
+      ctx.lineWidth = 5;
+      ctx.beginPath();
+      if (hasSignal) {
+        const bufferSize = timeData.length;
+        const samples = Array.from({ length: bufferSize }, (_, i) => normalizeSample(timeData[i] ?? 0));
+        let triggerIndex = samples.findIndex((v, i, arr) => i > 0 && arr[i - 1] > 0 && v <= 0);
+        if (triggerIndex < 0) triggerIndex = 0;
+        const usable = Math.max(1, bufferSize - triggerIndex);
+        for (let i = triggerIndex; i < bufferSize; i += 1) {
+          const x = ((i - triggerIndex) / usable) * w;
+          const y = mid - samples[i] * (h * 0.34);
+          if (i === triggerIndex) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        }
+      } else {
+        ctx.moveTo(0, mid);
+        ctx.lineTo(w, mid);
+      }
+      ctx.stroke();
+
+      ctx.strokeStyle = "#00f2b1";
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      if (hasSignal) {
+        const bufferSize = timeData.length;
+        const samples = Array.from({ length: bufferSize }, (_, i) => normalizeSample(timeData[i] ?? 0));
+        let triggerIndex = samples.findIndex((v, i, arr) => i > 0 && arr[i - 1] > 0 && v <= 0);
+        if (triggerIndex < 0) triggerIndex = 0;
+        const usable = Math.max(1, bufferSize - triggerIndex);
+        for (let i = triggerIndex; i < bufferSize; i += 1) {
+          const x = ((i - triggerIndex) / usable) * w;
+          const y = mid - samples[i] * (h * 0.34);
+          if (i === triggerIndex) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        }
+      } else {
+        ctx.moveTo(0, mid);
+        ctx.lineTo(w, mid);
+      }
+      ctx.stroke();
+
+      ctx.fillStyle = "rgba(186, 255, 234, 0.88)";
+      ctx.font = "11px monospace";
+      ctx.fillText(hasSignal ? "OSCI: AUDIO" : "OSCI: IDLE", 8, 16);
+
+      raf = window.requestAnimationFrame(draw);
+    };
+
+    raf = window.requestAnimationFrame(draw);
+
+    return () => {
+      window.cancelAnimationFrame(raf);
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("strudel-scope-data", onScopeData as EventListener);
+    };
+  }, []);
+
+  return (
+    <div
+      style={{
+        flex: "1 1 auto",
+        minHeight: 0,
+        minWidth: 0,
+        overflow: "hidden",
+        background: "#0d1010",
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "block",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/windows/ProgramWindow.tsx
+++ b/src/components/windows/ProgramWindow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   Anchor,
   Button,
@@ -37,6 +37,7 @@ export default function ProgramWindow({
   const changesTreeRef = useRef<ChangesTreeViewHandle>(null);
   const strudelRef = useRef<StrudelReplHandle>(null);
   const [strudelPlaying, setStrudelPlaying] = useState(false);
+  const [strudelLevel, setStrudelLevel] = useState(0);
 
   const title =
     id === "notepad"
@@ -45,12 +46,13 @@ export default function ProgramWindow({
         ? "issues.exe"
         : id === "changes"
           ? "changes.exe"
-          : id === "osci"
+          : id === "music"
             ? "strudel.cc"
         : "mrwr.dev";
 
-  const normalHeight = id === "welcome" ? 160 : id === "changes" ? 360 : id === "osci" ? 220 : 300;
+  const normalHeight = id === "welcome" ? 160 : id === "changes" ? 360 : id === "music" ? 220 : 300;
   const normalWidth = id === "changes" ? 320 : undefined;
+  const musicFrameEffect = id === "music" ? Math.min(1, (strudelPlaying ? 0.12 : 0) + strudelLevel * 0.8) : 0;
 
   const toolbar =
     id === "issues" ? (
@@ -89,7 +91,7 @@ export default function ProgramWindow({
           ➖
         </Button>
       </>
-    ) : id === "osci" ? (
+    ) : id === "music" ? (
       <>
         <Button
           variant="menu"
@@ -138,6 +140,7 @@ export default function ProgramWindow({
       layout={layout}
       normalWidth={normalWidth}
       normalHeight={normalHeight}
+      effectOutline={musicFrameEffect}
       onClose={onClose}
       onMinimize={onMinimize}
       onRestore={onRestore}
@@ -145,20 +148,29 @@ export default function ProgramWindow({
       toolbar={toolbar}
     >
       {id === "welcome" && (
-        <div>
-          coming soon…
-          <br />
-          you can help:
-          <ul>
-            <li>- found a bug? let me know!</li>
-            <li>- type brief description in search bar</li>
-            <li>
-              - buy me a{" "}
-              <Anchor href="https://buymeacoffee.com/rattmouse" target="_blank">
-                ☕
-              </Anchor>
-            </li>
-          </ul>
+        <div
+          style={{
+            flex: "1 1 auto",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "stretch",
+          }}
+        >
+          <div style={{ textAlign: "center" }}>coming soon…</div>
+          <div style={{ textAlign: "left", marginTop: 6 }}>
+            you can help:
+            <ul>
+              <li>- found a bug? let me know!</li>
+              <li>- type brief description in search bar</li>
+              <li>
+                - buy me a{" "}
+                <Anchor href="https://buymeacoffee.com/rattmouse" target="_blank">
+                  ☕
+                </Anchor>
+              </li>
+            </ul>
+          </div>
         </div>
       )}
 
@@ -193,7 +205,13 @@ export default function ProgramWindow({
         </div>
       )}
 
-      {id === "osci" && <StrudelReplWindow ref={strudelRef} onPlayingChange={setStrudelPlaying} />}
+      {id === "music" && (
+        <StrudelReplWindow
+          ref={strudelRef}
+          onPlayingChange={setStrudelPlaying}
+          onLevelChange={setStrudelLevel}
+        />
+      )}
     </DesktopWindow>
   );
 }

--- a/src/components/windows/StrudelReplWindow.tsx
+++ b/src/components/windows/StrudelReplWindow.tsx
@@ -13,6 +13,7 @@ type StrudelWebModule = {
   initAudio?: () => Promise<unknown>;
   initAudioOnFirstClick?: () => void;
   getAudioContext?: () => AudioContext | null;
+  getAnalyzerData?: (kind: "time" | "frequency", id: number) => ArrayLike<number> | undefined;
   evaluate?: (code: string, autostart?: boolean) => Promise<unknown>;
   hush?: () => void;
 };
@@ -40,20 +41,40 @@ const DEFAULT_CODE = `note("c2 e2 g2 b2")
   .s("sawtooth")
   .slow(2)
   .gain(0.5)`;
+const ANALYZER_ID = 1;
 
 type StrudelReplWindowProps = {
   onPlayingChange?: (playing: boolean) => void;
+  onLevelChange?: (level: number) => void;
 };
 
+function withAnalyzer(code: string): string {
+  const trimmed = code.trim().replace(/;+\s*$/, "");
+  if (!trimmed) return code;
+  if (/\banalyze\s*\(/.test(trimmed)) return trimmed;
+  return `(${trimmed}).analyze(${ANALYZER_ID})`;
+}
+
+function withAnalyzerSuffix(code: string): string {
+  const trimmed = code.trim().replace(/;+\s*$/, "");
+  if (!trimmed) return code;
+  if (/\banalyze\s*\(/.test(trimmed)) return trimmed;
+  return `${trimmed}\n.analyze(${ANALYZER_ID})`;
+}
+
 const StrudelReplWindow = forwardRef<StrudelReplHandle, StrudelReplWindowProps>(function StrudelReplWindow(
-  { onPlayingChange },
+  { onPlayingChange, onLevelChange },
   ref
 ) {
   const [ready, setReady] = useState(false);
   const editorRootRef = useRef<HTMLDivElement | null>(null);
+  const waveGlowPathRef = useRef<SVGPathElement | null>(null);
+  const wavePathRef = useRef<SVGPathElement | null>(null);
   const editorRef = useRef<EditorInstance | null>(null);
   const webRef = useRef<StrudelWebModule | null>(null);
   const codeRef = useRef(DEFAULT_CODE);
+  const levelLastEmitAtRef = useRef(0);
+  const levelLastValueRef = useRef(0);
 
   const ensureAudio = async () => {
     const web = webRef.current;
@@ -71,7 +92,16 @@ const StrudelReplWindow = forwardRef<StrudelReplHandle, StrudelReplWindowProps>(
     if (!ready || !web?.evaluate) return;
     try {
       await ensureAudio();
-      await web.evaluate(codeRef.current, true);
+      try {
+        await web.evaluate(withAnalyzer(codeRef.current), true);
+      } catch (wrappedErr) {
+        try {
+          await web.evaluate(withAnalyzerSuffix(codeRef.current), true);
+        } catch {
+          console.warn("Analyzer injection failed, running raw code.", wrappedErr);
+          await web.evaluate(codeRef.current, true);
+        }
+      }
       onPlayingChange?.(true);
     } catch (err) {
       console.error("Strudel update error:", err);
@@ -173,6 +203,81 @@ const StrudelReplWindow = forwardRef<StrudelReplHandle, StrudelReplWindowProps>(
     };
   }, []);
 
+  useEffect(() => {
+    let raf = 0;
+    const animate = (now: number) => {
+      const wave = wavePathRef.current;
+      const waveGlow = waveGlowPathRef.current;
+      if (wave && waveGlow) {
+        const samples = webRef.current?.getAnalyzerData?.("time", ANALYZER_ID);
+        const pointCount = 64;
+        const dParts: string[] = ["M 0 50"];
+
+        if (samples && samples.length > 0) {
+          const sampleCount = samples.length;
+          let triggerIndex = 0;
+          for (let i = 1; i < sampleCount; i += 1) {
+            const prevRaw = Number(samples[i - 1] ?? 0);
+            const currRaw = Number(samples[i] ?? 0);
+            const prev = prevRaw >= -1 && prevRaw <= 1 ? prevRaw : (prevRaw / 128) - 1;
+            const curr = currRaw >= -1 && currRaw <= 1 ? currRaw : (currRaw / 128) - 1;
+            if (prev > 0 && curr <= 0) {
+              triggerIndex = i;
+              break;
+            }
+          }
+          for (let i = 0; i <= pointCount; i += 1) {
+            const x = (i / pointCount) * 100;
+            const idx = (triggerIndex + Math.floor((i / pointCount) * (sampleCount - 1))) % sampleCount;
+            const raw = Number(samples[idx] ?? 0);
+            const normalized = raw >= -1 && raw <= 1 ? raw : (raw / 128) - 1;
+            const y = 50 - normalized * 40;
+            dParts.push(`L ${x.toFixed(2)} ${y.toFixed(2)}`);
+          }
+        } else {
+          dParts.push("L 100 50");
+        }
+        const d = dParts.join(" ");
+        wave.setAttribute("d", d);
+        waveGlow.setAttribute("d", d);
+      }
+      raf = window.requestAnimationFrame(animate);
+    };
+    raf = window.requestAnimationFrame(animate);
+    return () => {
+      window.cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  useEffect(() => {
+    let raf = 0;
+    const tick = (now: number) => {
+      const data = webRef.current?.getAnalyzerData?.("time", ANALYZER_ID);
+      let level = 0;
+      if (data && data.length) {
+        let sum = 0;
+        const count = data.length;
+        for (let i = 0; i < count; i += 1) {
+          const v = Number(data[i] ?? 0);
+          const normalized = v >= -1 && v <= 1 ? v : (v / 128) - 1;
+          sum += Math.abs(normalized);
+        }
+        level = Math.min(1, (sum / count) * 2.2);
+      }
+      if (onLevelChange && (now - levelLastEmitAtRef.current > 66 || Math.abs(level - levelLastValueRef.current) > 0.08)) {
+        levelLastEmitAtRef.current = now;
+        levelLastValueRef.current = level;
+        onLevelChange(level);
+      }
+      raf = window.requestAnimationFrame(tick);
+    };
+    raf = window.requestAnimationFrame(tick);
+    return () => {
+      window.cancelAnimationFrame(raf);
+      onLevelChange?.(0);
+    };
+  }, [onLevelChange]);
+
   return (
     <div
       style={{
@@ -184,8 +289,55 @@ const StrudelReplWindow = forwardRef<StrudelReplHandle, StrudelReplWindowProps>(
         background: "var(--background, #222)",
         overflow: "hidden",
       }}
-      ref={editorRootRef}
-    />
+    >
+      <div
+        style={{
+          flex: "0 0 20px",
+          minHeight: 20,
+          borderTop: "1px solid #808080",
+          background: "#121414",
+          overflow: "hidden",
+        }}
+      >
+        <svg
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          style={{ width: "100%", height: "100%", display: "block" }}
+        >
+          <path ref={waveGlowPathRef} d="M 0 50 L 100 50" fill="none" stroke="rgba(0,245,179,0.30)" strokeWidth="10" />
+          <path ref={wavePathRef} d="M 0 50 L 100 50" fill="none" stroke="#00f5b3" strokeWidth="2" />
+        </svg>
+      </div>
+      <div
+        ref={editorRootRef}
+        style={{
+          flex: "1 1 auto",
+          minWidth: 0,
+          minHeight: 0,
+          overflow: "hidden",
+          position: "relative",
+        }}
+      >
+        {!ready && (
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#cfcfcf",
+              fontFamily: "monospace",
+              fontSize: 12,
+              background: "#121414",
+              zIndex: 1,
+            }}
+          >
+            loading strudel...
+          </div>
+        )}
+      </div>
+    </div>
   );
 });
 

--- a/src/components/windows/windowTypes.ts
+++ b/src/components/windows/windowTypes.ts
@@ -1,12 +1,12 @@
-export type WindowId = "welcome" | "about" | "projects" | "contact" | "notepad" | "issues" | "changes" | "osci";
+export type WindowId = "welcome" | "about" | "projects" | "contact" | "notepad" | "issues" | "changes" | "music";
 
-export type ProgramWindowId = "welcome" | "notepad" | "issues" | "changes" | "osci";
+export type ProgramWindowId = "welcome" | "notepad" | "issues" | "changes" | "music";
 export type DocumentWindowId = "about" | "projects" | "contact";
 
 export type Layout = "normal" | "docked" | "maximized";
 
 export function isProgramWindow(id: WindowId): id is ProgramWindowId {
-  return id === "welcome" || id === "notepad" || id === "issues" || id === "changes" || id === "osci";
+  return id === "welcome" || id === "notepad" || id === "issues" || id === "changes" || id === "music";
 }
 
 export function isDocumentWindow(id: WindowId): id is DocumentWindowId {


### PR DESCRIPTION
## Summary
- restore single-window desktop behavior while keeping music-focused workflow
- move/reshape music osc display into a thin strip under toolbar and above editor
- improve mobile behavior for strudel initialization and controls with reduced render pressure
- adjust welcome layout alignment and menu/window wiring updates

## Verification
- npm run build